### PR TITLE
EchoAsync fix for proper decoding UTF-8 buffers

### DIFF
--- a/src/SyslogProxy/Proxy.cs
+++ b/src/SyslogProxy/Proxy.cs
@@ -43,6 +43,8 @@
             Logger.Information("New client connected from IP: [{0}].", ipAddress);
             using (client)
             {
+                var decoder = Encoding.UTF8.GetDecoder();
+                char[] decoded = new char[BufferSize];
                 var stream = client.GetStream();
                 var buf = new byte[BufferSize];
                 var accumulator = new StringBuilder();
@@ -63,7 +65,10 @@
                     {
                         break;
                     }
-                    accumulator.Append(Encoding.UTF8.GetString(buf).TrimEnd('\0'));
+
+                    var countDecoded = decoder.GetChars(buf, 0, amountReadTask.Result, decoded, 0);
+                    accumulator.Append(decoded, 0, countDecoded);
+
                     if (accumulator.ToString().Contains("\n"))
                     {
                         var splitMessage = accumulator.ToString().Split('\n').ToList();


### PR DESCRIPTION
Due to the fragmentation of TCP transmission, you cannot reliably expect the 'buf' buffer to always end on a full UTF-8 encoded character boundary. Calling UTF8.GetString(buf) when buf has end-bytes that do not fully make up a proper character can create garbage in the text. Using a UTF-8 Decoder is the proper way to accumulate UTF-8 text over a series of byte buffers. I will submit a pull request for the issue.